### PR TITLE
Compile Cairo from scratch for all Linux builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,15 @@ test-command = "pytest --exitfirst --verbose --failed-first {package}/tests"
 before-all = [
     # Has eigen3-devel.aarch64
     "yum install -y epel-release",
-    "yum install -y wget freetype-devel zlib-devel libpng12-devel pixman-devel eigen3-devel cairo-devel",
+    "yum install -y wget freetype-devel libpng12-devel pixman-devel zlib-devel eigen3-devel",
+    # cairo-devel from the centos repo does not work, build here
+    "wget https://www.cairographics.org/snapshots/cairo-1.15.14.tar.xz --no-check-certificate",
+    "tar xvf cairo-*",
+    "cd cairo-*",
+    "./configure",
+    "make -j 20",
+    "make install",
+    "cd ..",
 ]
 
 repair-wheel-command = [

--- a/setup.py
+++ b/setup.py
@@ -255,7 +255,7 @@ class BuildRDKit(build_ext_orig):
 
 setup(
     name="rdkit-pypi",
-    version=rdkit_tag.replace("Release_", "").replace("_", "."),
+    version=rdkit_tag.replace("Release_", "").replace("_", ".") + ".1",
     description="A collection of chemoinformatics and machine-learning software written in C++ and Python",
     author="Christopher Kuenneth",
     author_email="chris@kuenneth.dev",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,3 +27,9 @@ def test_data_dir_and_chemical_features():
     m = Chem.MolFromSmiles("OCc1ccccc1CN")
     feats = factory.GetFeaturesForMol(m)
     assert len(feats) == 8
+
+
+def test_rdkit_chem_draw_import():
+    # This segfaults if the compiled cairo version from centos is used
+    from rdkit.Chem.Draw import ReactionToImage
+    from rdkit.Chem.Draw import IPythonConsole

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,4 +32,3 @@ def test_data_dir_and_chemical_features():
 def test_rdkit_chem_draw_import():
     # This segfaults if the compiled cairo version from centos is used
     from rdkit.Chem.Draw import ReactionToImage
-    from rdkit.Chem.Draw import IPythonConsole


### PR DESCRIPTION
The RDKit draw module raises a segmentation fault if compiled with the cairo version in the CentOS repository. Compiling Cairo from scratch solves this problem. Closes #24 and #32. 