### PR TITLE
`uncaught_exceptions` missing in MacOS C++17

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,7 +1,7 @@
 
 name: Build wheels
 
-on: [push, pull_request]
+on: push
 
 
 jobs:

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ class BuildRDKit(build_ext_orig):
         if sys.platform == "darwin":
             options += [
                 "-DCMAKE_C_FLAGS=-Wno-implicit-function-declaration",
-                "-DCMAKE_CXX_FLAGS=-Wno-implicit-function-declaration",
+                "-DCMAKE_CXX_FLAGS=-Wno-implicit-function-declaration -DCATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS",
             ]
 
         vars = {}

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ class BuildRDKit(build_ext_orig):
             f"cmake --build build -j 4 --config Release",
             f"cmake --install build",
         ]
-        [check_call(shlex.split(c, posix="win" not in sys.platform), env=dict(os.environ, **vars)) for c in cmds]
+        [check_call(shlex.split(c, posix="win32" not in sys.platform), env=dict(os.environ, **vars)) for c in cmds]
 
         os.chdir(str(cwd))
 

--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,7 @@ class BuildRDKit(build_ext_orig):
         if sys.platform == "darwin":
             options += [
                 "-DCMAKE_C_FLAGS=-Wno-implicit-function-declaration",
+                # CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS because MacOS does not fully support C++17.
                 '-DCMAKE_CXX_FLAGS="-Wno-implicit-function-declaration -DCATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS"',
             ]
 
@@ -198,7 +199,7 @@ class BuildRDKit(build_ext_orig):
             f"cmake --build build -j 4 --config Release",
             f"cmake --install build",
         ]
-        [check_call(shlex.split(c), env=dict(os.environ, **vars)) for c in cmds]
+        [check_call(shlex.split(c, posix="win" not in sys.platform), env=dict(os.environ, **vars)) for c in cmds]
 
         os.chdir(str(cwd))
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import sys
 from distutils.file_util import copy_file
 from pathlib import Path
@@ -176,7 +177,7 @@ class BuildRDKit(build_ext_orig):
         if sys.platform == "darwin":
             options += [
                 "-DCMAKE_C_FLAGS=-Wno-implicit-function-declaration",
-                "-DCMAKE_CXX_FLAGS=-Wno-implicit-function-declaration -DCATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS",
+                '-DCMAKE_CXX_FLAGS="-Wno-implicit-function-declaration -DCATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS"',
             ]
 
         vars = {}
@@ -195,7 +196,7 @@ class BuildRDKit(build_ext_orig):
             f"cmake --build build -j 4 --config Release",
             f"cmake --install build",
         ]
-        [check_call(c.split(), env=dict(os.environ, **vars)) for c in cmds]
+        [check_call(shlex.split(c), env=dict(os.environ, **vars)) for c in cmds]
 
         os.chdir(str(cwd))
 


### PR DESCRIPTION
RDKit now compiles with the C++17 standard (https://github.com/rdkit/rdkit/pull/5155).  MacOS has not fully implemented this standard. `uncaught_exceptions` is not available in `libc++.dylib` for some versions.  

Defining `CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS` for MacOS builds instructs Catch to use a different implementation. 
