### PR TITLE
Enable building and installing rdkit-stubs as part of the recipe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires = [
     "oldest-supported-numpy",
     "conan == 1.62.0",
     "ninja",
+    "pybind11-stubgen",
     ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -258,6 +258,7 @@ class BuildRDKit(build_ext_orig):
             f"cmake -S . -B build {' '.join(options)} ",
             "cmake --build build -j 4 --config Release -v",
             "cmake --install build",
+            "cmake --build build --config Release --target stubs",
         ]
 
         print('!!! --- CMAKE build command', file=sys.stderr)

--- a/setup.py
+++ b/setup.py
@@ -254,6 +254,16 @@ class BuildRDKit(build_ext_orig):
             # also export it to compile yaehmop for arm64
             vars["CMAKE_OSX_ARCHITECTURES"] = "arm64"
 
+        rdkit_files = rdkit_install_path / "lib" / py_name / "site-packages" / "rdkit"
+        if sys.platform == "win32":
+            rdkit_files = rdkit_install_path / "Lib" / "site-packages" / "rdkit"
+
+        old_pythonpath = os.environ.get("PYTHONPATH", None)
+        new_pythonpath = os.path.dirname(rdkit_files)
+        if old_pythonpath:
+            new_pythonpath += os.pathsep + old_pythonpath
+        vars["PYTHONPATH"] = new_pythonpath
+
         cmds = [
             f"cmake -S . -B build {' '.join(options)} ",
             "cmake --build build -j 4 --config Release -v",
@@ -277,10 +287,6 @@ class BuildRDKit(build_ext_orig):
 
         # Copy RDKit and additional files to the wheel path
         py_name = "python" + ".".join(map(str, sys.version_info[:2]))
-        rdkit_files = rdkit_install_path / "lib" / py_name / "site-packages" / "rdkit"
-
-        if sys.platform == "win32":
-            rdkit_files = rdkit_install_path / "Lib" / "site-packages" / "rdkit"
 
         # Modify RDPaths.py
         sed = "gsed" if sys.platform == "darwin" else "sed"


### PR DESCRIPTION
@kuelumbus 
This PR should allow building an `rdkit-stubs` directory and installing it into the same `site-packages` directory where the `rdkit` directory containing Python modules is installed.
`rdkit-stubs` enable useful pop-ups with type hints and docstrings in VSCode and similar IDEs, and also enable static code analysis using `mypy` as described in this blog post:
https://greglandrum.github.io/rdkit-blog/posts/2024-03-08-docstring-stubs.html