### PR TITLE
Support NumPy 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -408,7 +408,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=[
-        "numpy < 2.0",
+        "numpy >= 1",
         "Pillow",
     ],
     ext_modules=[


### PR DESCRIPTION
Via https://github.com/rdkit/rdkit/pull/7531 RDKit support NumPy 2.0. However, the `setup.py` does not reflect this, yet. This PR allows both NumPy 1.x and 2.x as installation requirement.