### PR TITLE
Enable Python 3.13 builds in GH actions and circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ workflows:
       - linux-arm64-wheels:
           matrix:
             parameters:
-              python-version: ["39", "310", "311", "312"]
+              python-version: ["39", "310", "311", "312", "313"]
       # - osx-wheels:
       #     matrix:
       #       parameters:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,10 +42,10 @@ jobs:
             python: 312
             bitness: 64
             platform_id: win_amd64
-          # - os: windows-2019
-          #   python: 313
-          #   bitness: 64
-          #   platform_id: win_amd64
+          - os: windows-2019
+            python: 313
+            bitness: 64
+            platform_id: win_amd64
 
           # Linux 64 bit Intel: x86_64
           - os: ubuntu-latest
@@ -64,10 +64,10 @@ jobs:
             python: 312
             bitness: 64
             platform_id: manylinux_x86_64
-          # - os: ubuntu-latest
-          #   python: 313
-          #   bitness: 64
-          #   platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 313
+            bitness: 64
+            platform_id: manylinux_x86_64
 
           # Linux 64 bit ARM: aarch64 (on Circle CI)
 
@@ -88,10 +88,10 @@ jobs:
             bitness: 64
             python: 312
             platform_id: macosx_arm64
-          # - os: macos-14
-          #   bitness: 64
-          #   python: 313
-          #   platform_id: macosx_arm64
+          - os: macos-14
+            bitness: 64
+            python: 313
+            platform_id: macosx_arm64
 
           # MacOS 64 bit Intel: x86_64
           - os: macos-12
@@ -110,10 +110,10 @@ jobs:
             bitness: 64
             python: 312
             platform_id: macosx_x86_64
-          # - os: macos-12
-          #   bitness: 64
-          #   python: 313
-          #   platform_id: macosx_x86_64
+          - os: macos-12
+            bitness: 64
+            python: 313
+            platform_id: macosx_x86_64
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Please open an issue if you find something missing or not working as expected.
 ![GitHub Repo stars](https://img.shields.io/github/stars/kuelumbus/rdkit-pypi?style=for-the-badge&logo=github)
 ## Available Builds
 
-| OS      | Arch    | Bit | Conditions                                          | 3.8            | 3.9 | 3.10 | 3.11 | 3.12 | CI                |
-| ------- | ------- | --- | --------------------------------------------------- | -------------- | --- | ---- | ---- | ---- | ----------------- |
-| Linux   | intel   | 64  | glibc >= 2.28 (e.g., Ubuntu 18.04+, CentOS 6+, ...) | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | Github Actions    |
-| Linux   | aarch64 | 64  | glibc >= 2.28 (e.g., Raspberry Pi, ...)             | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | Circle CI         |
-| macOS   | intel   | 64  | >= macOS 10.13                                      | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | Github Actions    |
-| macOS   | armv8   | 64  | >= macOS 11, M1 hardware                            | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | Github Actions |
-| Windows | intel   | 64  |                                                     | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | Github Actions    |
+| OS      | Arch    | Bit | Conditions                                          | 3.8            | 3.9 | 3.10 | 3.11 | 3.12 | 3.13 | CI             |
+| ------- | ------- | --- | --------------------------------------------------- | -------------- | --- | ---- | ---- | ---- | ---- | -------------- |
+| Linux   | intel   | 64  | glibc >= 2.28 (e.g., Ubuntu 18.04+, CentOS 6+, ...) | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
+| Linux   | aarch64 | 64  | glibc >= 2.28 (e.g., Raspberry Pi, ...)             | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Circle CI      |
+| macOS   | intel   | 64  | >= macOS 10.13                                      | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
+| macOS   | armv8   | 64  | >= macOS 11, M1 hardware                            | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
+| Windows | intel   | 64  |                                                     | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
 
 ## Installation
 


### PR DESCRIPTION
Waiting for https://github.com/rdkit/rdkit/issues/7731