### PR TITLE
Bump rdkit release 2024 09 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 import os
 import shlex
 import sys
-import sysconfig
 from distutils.file_util import copy_file
 from pathlib import Path
-from shutil import copytree, ignore_patterns, rmtree
+from shutil import copytree, rmtree, ignore_patterns
 from subprocess import call, check_call
+import sysconfig
 from textwrap import dedent
 
 from setuptools import Extension, find_packages, setup

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 import os
 import shlex
 import sys
+import sysconfig
 from distutils.file_util import copy_file
 from pathlib import Path
-from shutil import copytree, rmtree, ignore_patterns
+from shutil import copytree, ignore_patterns, rmtree
 from subprocess import call, check_call
-import sysconfig
 from textwrap import dedent
 
 from setuptools import Extension, find_packages, setup
@@ -227,7 +227,7 @@ freetype/2.13.2
             # Speed up builds
             "-DRDK_BUILD_CPP_TESTS=OFF",
             # Fix InChi download
-            "-DINCHI_URL=https://rdkit.org/downloads/INCHI-1-SRC.zip",
+            "-DINCHI_URL=https://github.com/IUPAC-InChI/InChI/releases/download/v1.07.2/INCHI-1-SRC.zip",
         ]
 
         # Modifications for Windows


### PR DESCRIPTION
New URL is https://github.com/IUPAC-InChI/InChI/releases/download/v1.07.2/INCHI-1-SRC.zip, which is updated here. per [RDKit PR 8176](https://github.com/rdkit/rdkit/pull/8176/files#diff-d2a84266958b3cc404a4393f4b0f2754c47525ad2d0d7dd9fbc5780641e1790aR42) , md5 checksum is b802d6ed8b4eb5f3eaf0782cba3499aa.