### PR TITLE
Generalize macOS armv8 hardware to M-series

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please open an issue if you find something missing or not working as expected.
 | Linux   | intel   | 64  | glibc >= 2.28 (e.g., Ubuntu 18.04+, CentOS 6+, ...) | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
 | Linux   | aarch64 | 64  | glibc >= 2.28 (e.g., Raspberry Pi, ...)             | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Circle CI      |
 | macOS   | intel   | 64  | >= macOS 10.15                                      | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
-| macOS   | armv8   | 64  | >= macOS 11, M1 hardware                            | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    |  ✔️   | Github Actions |
+| macOS   | armv8   | 64  | >= macOS 11, M-series hardware (M1, M2, M3, ...)   | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    |  ✔️   | Github Actions |
 | Windows | intel   | 64  |                                                     | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please open an issue if you find something missing or not working as expected.
 | Linux   | intel   | 64  | glibc >= 2.28 (e.g., Ubuntu 18.04+, CentOS 6+, ...) | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
 | Linux   | aarch64 | 64  | glibc >= 2.28 (e.g., Raspberry Pi, ...)             | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Circle CI      |
 | macOS   | intel   | 64  | >= macOS 10.15                                      | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
-| macOS   | armv8   | 64  | >= macOS 11, M-series hardware (M1, M2, M3, ...)   | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    |  ✔️   | Github Actions |
+| macOS   | aarch64 | 64  | >= macOS 11,                                        | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    |  ✔️   | Github Actions |
 | Windows | intel   | 64  |                                                     | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please open an issue if you find something missing or not working as expected.
 | Linux   | intel   | 64  | glibc >= 2.28 (e.g., Ubuntu 18.04+, CentOS 6+, ...) | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
 | Linux   | aarch64 | 64  | glibc >= 2.28 (e.g., Raspberry Pi, ...)             | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Circle CI      |
 | macOS   | intel   | 64  | >= macOS 10.15                                      | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
-| macOS   | aarch64 | 64  | >= macOS 11,                                        | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    |  ✔️   | Github Actions |
+| macOS   | aarch64 | 64  | >= macOS 11                                         | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    |  ✔️   | Github Actions |
 | Windows | intel   | 64  |                                                     | last: 2024.3.5 | ✔️   | ✔️    | ✔️    | ✔️    | ✔️    | Github Actions |
 
 ## Installation


### PR DESCRIPTION
Update macOS armv8 hardware description in README.md: Generalize to M-series hardware (M1, M2, M3, ...).

I use the RDKit from PyPI on an M2 Mac, so I assume all M-series hardware is supported.