### PR TITLE
Add Windows ARM64 build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,9 +6,9 @@ on:
   push:
     branches: [ main ]
   pull_request:
-  
 
-permissions: 
+
+permissions:
   contents: write
 
 env:
@@ -25,27 +25,55 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Window 64 bit
+          # Windows 64 bit
           - os: windows-2022
             python: 310
             bitness: 64
             platform_id: win_amd64
+            vcpkg_triplet: x64-windows
           - os: windows-2022
             python: 311
             bitness: 64
             platform_id: win_amd64
+            vcpkg_triplet: x64-windows
           - os: windows-2022
             python: 312
             bitness: 64
             platform_id: win_amd64
+            vcpkg_triplet: x64-windows
           - os: windows-2022
             python: 313
             bitness: 64
             platform_id: win_amd64
+            vcpkg_triplet: x64-windows
           - os: windows-2022
             python: 314
             bitness: 64
             platform_id: win_amd64
+            vcpkg_triplet: x64-windows
+
+          # Windows 64 bit ARM: arm64
+          # CPython only ships official win_arm64 builds from 3.11 onwards
+          - os: windows-11-arm
+            python: 311
+            bitness: 64
+            platform_id: win_arm64
+            vcpkg_triplet: arm64-windows
+          - os: windows-11-arm
+            python: 312
+            bitness: 64
+            platform_id: win_arm64
+            vcpkg_triplet: arm64-windows
+          - os: windows-11-arm
+            python: 313
+            bitness: 64
+            platform_id: win_arm64
+            vcpkg_triplet: arm64-windows
+          - os: windows-11-arm
+            python: 314
+            bitness: 64
+            platform_id: win_arm64
+            vcpkg_triplet: arm64-windows
 
           # Linux 64 bit Intel: x86_64
           - os: ubuntu-latest
@@ -121,13 +149,13 @@ jobs:
       - name: Copy to C:\
         if: ${{ runner.os == 'Windows' }}
         run: |
-          Copy-Item -Path D:\a\rdkit-pypi\rdkit-pypi -Destination C:\rdkit -Recurse
+          Copy-Item -Path "${{ github.workspace }}" -Destination C:\rdkit -Recurse
 
       - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.13'
-      
+
       - name: Export GitHub Actions cache environment variables for vcpkg
         if: ${{ runner.os == 'Windows' }}
         uses: actions/github-script@v7
@@ -135,12 +163,12 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-      
+
       - name: Install libraries with vcpkg
         if: ${{ runner.os == 'Windows' }}
         run: |
           cd C:\\rdkit
-          vcpkg --triplet x64-windows install
+          vcpkg --triplet ${{ matrix.vcpkg_triplet }} install
 
       - name: Install libraries with chocolatey
         if: ${{ runner.os == 'Windows' }}
@@ -173,5 +201,5 @@ jobs:
         with:
           name: cp${{ matrix.python }}-${{ matrix.platform_id }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
-      
+
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -39,6 +39,11 @@ class RDKitConan(ConanFile):
             # tr1 sources ask for, and fails with C3859 / C1076.
             self.options["boost/*"].pch = False
 
+            # boost_context's arm64 assembly does not export make/jump_fcontext, so
+            # the shared boost_coroutine cannot link. RDKit uses neither library.
+            self.options["boost/*"].without_context = True
+            self.options["boost/*"].without_coroutine = True
+
     def requirements(self):
         # Main boost requirement - use modified version
         self.requires("boost/1.85.0@chris/mod_boost")

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 class RDKitConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    
+
     def configure(self):
         # Configure boost options
         self.options["boost/*"].shared = True
@@ -27,24 +27,29 @@ class RDKitConan(ConanFile):
             self.options["boost/*"].without_stacktrace = True
         else:
             self.options["boost/*"].without_stacktrace = False
-            
+
         # Configure Python library linking for wheel building
         if self.settings.os == "Windows":
             self.options["boost/*"].without_python_lib = False
         else:
             self.options["boost/*"].without_python_lib = True
 
+        if self.settings.os == "Windows" and self.settings.arch == "armv8":
+            # The arm64 cl.exe cannot reserve the PCH address space Boost.Math's
+            # tr1 sources ask for, and fails with C3859 / C1076.
+            self.options["boost/*"].pch = False
+
     def requirements(self):
         # Main boost requirement - use modified version
         self.requires("boost/1.85.0@chris/mod_boost")
         # self.requires("boost/1.85.0")
         self.requires("expat/2.7.5")
-        
+
         # Platform-specific requirements
         if self.settings.os == "Macos" and os.environ.get("CIBW_BUILD", "").startswith("cp"):
             # macOS libraries to meet development target
             self.requires("pixman/0.43.4")
-            self.requires("cairo/1.18.0") 
+            self.requires("cairo/1.18.0")
             self.requires("libpng/1.6.43")
             self.requires("fontconfig/2.15.0")
             self.requires("freetype/2.13.2")
@@ -77,7 +82,7 @@ class RDKitConan(ConanFile):
         deps.set_property("cairo", "cmake_target_name", "Cairo::Cairo")
 
         deps.generate()
-        
+
         # Generate CMake toolchain
         tc = CMakeToolchain(self)
 
@@ -91,7 +96,7 @@ class RDKitConan(ConanFile):
         tc.extra_cflags.append("-I" + expat_inc)
 
         tc.generate()
-        
+
         # Generate virtual run environment
         env = VirtualRunEnv(self)
         env.generate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,11 @@ repair-wheel-command = [
     "delvewheel show -v --add-path C:\\libs;C:\\rdkit\\vcpkg_installed\\x64-windows\\bin {wheel}",
     "delvewheel repair -v --add-path C:\\libs;C:\\rdkit\\vcpkg_installed\\x64-windows\\bin -w {dest_dir} {wheel}"
     ]
+
+[[tool.cibuildwheel.overrides]]
+select = "*-win_arm64"
+repair-wheel-command = [
+    "C:\\rdkit\\conan\\conanrun.bat",
+    "delvewheel show -v --add-path C:\\libs;C:\\rdkit\\vcpkg_installed\\arm64-windows\\bin {wheel}",
+    "delvewheel repair -v --add-path C:\\libs;C:\\rdkit\\vcpkg_installed\\arm64-windows\\bin -w {dest_dir} {wheel}"
+    ]

--- a/setup.py
+++ b/setup.py
@@ -73,11 +73,6 @@ class BuildRDKit(build_ext_orig):
         if sys.platform == "win32":
             cmd += ["--profile:build", "default"]
 
-        # The boost recipe builds b2 with -d0, which hides the failing compiler
-        # command. Raise it to -d2 so arm64 build errors are visible in CI.
-        if "win_arm64" in os.environ["CIBW_BUILD"]:
-            cmd += ["-c", "tools.build:verbosity=verbose"]
-
         # but force build b2 on linux
         if "linux" in sys.platform:
             cmd += ["--build=b2/*", "--profile:build", "default"]

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,11 @@ class BuildRDKit(build_ext_orig):
         if sys.platform == "win32":
             cmd += ["--profile:build", "default"]
 
+        # The boost recipe builds b2 with -d0, which hides the failing compiler
+        # command. Raise it to -d2 so arm64 build errors are visible in CI.
+        if "win_arm64" in os.environ["CIBW_BUILD"]:
+            cmd += ["-c", "tools.build:verbosity=verbose"]
+
         # but force build b2 on linux
         if "linux" in sys.platform:
             cmd += ["--build=b2/*", "--profile:build", "default"]

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ class BuildRDKit(build_ext_orig):
         #             "0b8fc6fbf7bee2a0de34daee6088aeb8c8036272",
         #         ]
         #     )
-    
+
         import fileinput
 
         def replace_all(file, search_exp, replace_exp):
@@ -167,7 +167,7 @@ class BuildRDKit(build_ext_orig):
             'find_package(Python3 COMPONENTS Interpreter Development NumPy)',
         )
 
-  
+
 
         # Define CMake options
         options = [
@@ -199,14 +199,26 @@ class BuildRDKit(build_ext_orig):
         ]
 
         # Modifications for Windows
-        vcpkg_path = cwd
-        vcpkg_inc = vcpkg_path / "vcpkg_installed" / "x64-windows" / "include"
-        vcpkg_lib = vcpkg_path / "vcpkg_installed" / "x64-windows" / "lib"
-
         if sys.platform == "win32":
             def to_win_path(pt: Path):
                 return str(pt).replace("\\", "/")
-        
+
+            # Modifications for Windows x86_64
+            if "win_amd64" in os.environ["CIBW_BUILD"]:
+                vcpkg_triplet = "x64-windows"
+
+            # Modifications for Windows arm64
+            if "win_arm64" in os.environ["CIBW_BUILD"]:
+                vcpkg_triplet = "arm64-windows"
+                options += [
+                    # POPCNT is an x86-only intrinsic
+                    "-DRDK_OPTIMIZE_POPCNT=OFF",
+                ]
+
+            vcpkg_path = cwd
+            vcpkg_inc = vcpkg_path / "vcpkg_installed" / vcpkg_triplet / "include"
+            vcpkg_lib = vcpkg_path / "vcpkg_installed" / vcpkg_triplet / "lib"
+
             options += [
                 # DRDK_INSTALL_STATIC_LIBS should be fixed in newer RDKit builds. Remove?
                 "-DRDK_INSTALL_STATIC_LIBS=OFF",
@@ -284,12 +296,12 @@ class BuildRDKit(build_ext_orig):
         path_site_packages = rdkit_install_path / "lib" / py_name / "site-packages"
         if sys.platform == "win32":
             path_site_packages = rdkit_install_path / "Lib" / "site-packages"
-        
-        
+
+
         print("---- Conf vars", file=sys.stderr)
         print(sysconfig.get_paths(), file=sys.stderr)
         print(sysconfig.get_config_vars(), file=sys.stderr)
-        print("---- Conf vars", file=sys.stderr)     
+        print("---- Conf vars", file=sys.stderr)
 
 
         print("!!! --- CMAKE build command and variables for RDKit", file=sys.stderr)
@@ -394,7 +406,7 @@ class BuildRDKit(build_ext_orig):
         with open(stubs_error_file, "r") as fin:
             print(fin.read(), file=sys.stderr)
 
-        # Change directory here 
+        # Change directory here
         os.chdir(str(cwd))
 
         # Copy RDKit and additional files to the wheel path


### PR DESCRIPTION
As the title says. There were a couple of issues when compiling the specific version of Boost on Windows ARM64, so I have tweaked some settings to get that build to work.

Aside from that it was mainly a matter of changing hardcoded paths and triplets to parameterized ones.

My editor also cleaned up some lines with trailing whitespace.